### PR TITLE
Remove possibility to change underlying stream

### DIFF
--- a/src/main/php/net/stubbles/streams/AbstractDecoratedInputStream.php
+++ b/src/main/php/net/stubbles/streams/AbstractDecoratedInputStream.php
@@ -32,18 +32,6 @@ abstract class AbstractDecoratedInputStream extends BaseObject implements Decora
     }
 
     /**
-     * replace current enclosed input stream
-     *
-     * @param   InputStream  $inputStream
-     * @return  AbstractDecoratedInputStream
-     */
-    public function setEnclosedInputStream(InputStream $inputStream)
-    {
-        $this->inputStream = $inputStream;
-        return $this;
-    }
-
-    /**
      * returns enclosed input stream
      *
      * @return  InputStream

--- a/src/main/php/net/stubbles/streams/AbstractDecoratedOutputStream.php
+++ b/src/main/php/net/stubbles/streams/AbstractDecoratedOutputStream.php
@@ -32,18 +32,6 @@ abstract class AbstractDecoratedOutputStream extends BaseObject implements Decor
     }
 
     /**
-     * replace current enclosed output stream
-     *
-     * @param   OutputStream  $outputStream
-     * @return  AbstractDecoratedOutputStream
-     */
-    public function setEnclosedOutputStream(OutputStream $outputStream)
-    {
-        $this->outputStream = $outputStream;
-        return $this;
-    }
-
-    /**
      * returns enclosed output stream
      *
      * @return  OutputStream

--- a/src/main/php/net/stubbles/streams/DecoratedInputStream.php
+++ b/src/main/php/net/stubbles/streams/DecoratedInputStream.php
@@ -14,13 +14,6 @@ namespace net\stubbles\streams;
 interface DecoratedInputStream extends InputStream
 {
     /**
-     * replace current enclosed input stream
-     *
-     * @param  InputStream  $inputStream
-     */
-    public function setEnclosedInputStream(InputStream $inputStream);
-
-    /**
      * returns enclosed input stream
      *
      * @return  InputStream

--- a/src/main/php/net/stubbles/streams/DecoratedOutputStream.php
+++ b/src/main/php/net/stubbles/streams/DecoratedOutputStream.php
@@ -14,13 +14,6 @@ namespace net\stubbles\streams;
 interface DecoratedOutputStream extends OutputStream
 {
     /**
-     * replace current enclosed output stream
-     *
-     * @param  OutputStream  $outputStream
-     */
-    public function setEnclosedOutputStream(OutputStream $outputStream);
-
-    /**
      * returns enclosed output stream
      *
      * @return  OutputStream

--- a/src/test/php/net/stubbles/streams/AbstractDecoratedInputStreamTestCase.php
+++ b/src/test/php/net/stubbles/streams/AbstractDecoratedInputStreamTestCase.php
@@ -45,17 +45,12 @@ class AbstractDecoratedInputStreamTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * set() and get() enclosed input stream
-     *
      * @test
      */
-    public function setAndGetEnclosedInputStream()
+    public function returnsEnclosedInputStream()
     {
-        $this->assertSame($this->mockInputStream, $this->abstractDecoratedInputStream->getEnclosedInputStream());
-        $mockInputStream2 = $this->getMock('net\\stubbles\\streams\\InputStream');
-        $this->assertSame($mockInputStream2,
-                          $this->abstractDecoratedInputStream->setEnclosedInputStream($mockInputStream2)
-                                                             ->getEnclosedInputStream()
+        $this->assertSame($this->mockInputStream,
+                          $this->abstractDecoratedInputStream->getEnclosedInputStream()
         );
     }
 

--- a/src/test/php/net/stubbles/streams/AbstractDecoratedOutputStreamTestCase.php
+++ b/src/test/php/net/stubbles/streams/AbstractDecoratedOutputStreamTestCase.php
@@ -45,17 +45,12 @@ class AbstractDecoratedOutputStreamTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * set() and get() enclosed output stream
-     *
      * @test
      */
-    public function setAndGetEnclosedOutputStream()
+    public function returnsEnclosedOutputStream()
     {
-        $this->assertSame($this->mockOutputStream, $this->abstractDecoratedOutputStream->getEnclosedOutputStream());
-        $mockOutputStream2 = $this->getMock('net\\stubbles\\streams\\OutputStream');
-        $this->assertSame($mockOutputStream2,
-                          $this->abstractDecoratedOutputStream->setEnclosedOutputStream($mockOutputStream2)
-                                                              ->getEnclosedOutputStream()
+        $this->assertSame($this->mockOutputStream,
+                          $this->abstractDecoratedOutputStream->getEnclosedOutputStream()
         );
     }
 


### PR DESCRIPTION
It should not be possible to remove the underlying stream as this can have major consequences - this would seduce users to share the decorating steam what in fact is not possible to know whether the consuming code already finished working with this stream.
